### PR TITLE
fix: fixed error message for the issue #53

### DIFF
--- a/packages/dapp/src/hooks/useMyTokens.ts
+++ b/packages/dapp/src/hooks/useMyTokens.ts
@@ -164,9 +164,8 @@ export const useGetToken = (
 
         setLoading(false);
       } catch (err) {
-        console.log('@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@')
         logger.error(err);
-        const message = (err as Error).message || 'Unknown useGetToken error';
+        const message = `Unable to get token #${id}`;
         setError(message);
         setLoading(false);
       }


### PR DESCRIPTION
This PR is changing the long nonsense error message to: `Unable to get token #<tokenId>`